### PR TITLE
Merge adjacent reservations

### DIFF
--- a/internal/common/test/mocks/ReservationRepository.go
+++ b/internal/common/test/mocks/ReservationRepository.go
@@ -657,3 +657,72 @@ func (_c *MockReservationRepository_SelectUpcomingReservationsWithSpotForSpot_Ca
 	_c.Call.Return(run)
 	return _c
 }
+
+// UpdateReservation provides a mock function for the type MockReservationRepository
+func (_mock *MockReservationRepository) UpdateReservation(ctx context.Context, id int64, startAt time.Time, endAt time.Time) error {
+	ret := _mock.Called(ctx, id, startAt, endAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateReservation")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, time.Time, time.Time) error); ok {
+		r0 = returnFunc(ctx, id, startAt, endAt)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockReservationRepository_UpdateReservation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateReservation'
+type MockReservationRepository_UpdateReservation_Call struct {
+	*mock.Call
+}
+
+// UpdateReservation is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id int64
+//   - startAt time.Time
+//   - endAt time.Time
+func (_e *MockReservationRepository_Expecter) UpdateReservation(ctx interface{}, id interface{}, startAt interface{}, endAt interface{}) *MockReservationRepository_UpdateReservation_Call {
+	return &MockReservationRepository_UpdateReservation_Call{Call: _e.mock.On("UpdateReservation", ctx, id, startAt, endAt)}
+}
+
+func (_c *MockReservationRepository_UpdateReservation_Call) Run(run func(ctx context.Context, id int64, startAt time.Time, endAt time.Time)) *MockReservationRepository_UpdateReservation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		var arg2 time.Time
+		if args[2] != nil {
+			arg2 = args[2].(time.Time)
+		}
+		var arg3 time.Time
+		if args[3] != nil {
+			arg3 = args[3].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockReservationRepository_UpdateReservation_Call) Return(err error) *MockReservationRepository_UpdateReservation_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockReservationRepository_UpdateReservation_Call) RunAndReturn(run func(ctx context.Context, id int64, startAt time.Time, endAt time.Time) error) *MockReservationRepository_UpdateReservation_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/core/booking/booking.go
+++ b/internal/core/booking/booking.go
@@ -143,6 +143,10 @@ func (a *Adapter) Book(request book.BookRequest) ([]*reservation.ClippedOrRemove
 		go a.commSrv.NotifyOverbookedMember(request, res)
 	}
 
+	if err := a.mergeAdjacentReservations(context.Background(), request); err != nil {
+		return nil, fmt.Errorf("could not merge reservations: %w", err)
+	}
+
 	return res, nil
 }
 

--- a/internal/core/booking/booking.go
+++ b/internal/core/booking/booking.go
@@ -143,7 +143,7 @@ func (a *Adapter) Book(request book.BookRequest) ([]*reservation.ClippedOrRemove
 		go a.commSrv.NotifyOverbookedMember(request, res)
 	}
 
-	if err := a.mergeAdjacentReservations(context.Background(), request); err != nil {
+	if err := a.mergeAdjacentReservations(request); err != nil {
 		return nil, fmt.Errorf("could not merge reservations: %w", err)
 	}
 

--- a/internal/core/booking/booking.go
+++ b/internal/core/booking/booking.go
@@ -143,7 +143,7 @@ func (a *Adapter) Book(request book.BookRequest) ([]*reservation.ClippedOrRemove
 		go a.commSrv.NotifyOverbookedMember(request, res)
 	}
 
-	if err := a.mergeAdjacentReservations(request); err != nil {
+	if err := a.mergeAdjacentReservations(context.Background(), request); err != nil {
 		return nil, fmt.Errorf("could not merge reservations: %w", err)
 	}
 

--- a/internal/core/booking/booking_test.go
+++ b/internal/core/booking/booking_test.go
@@ -514,3 +514,50 @@ func TestBookFailOnOverbookAuthorsReservation(t *testing.T) {
 	assert.NotNil(err)
 	assert.Empty(res)
 }
+
+func TestBook_PostMerge(t *testing.T) {
+	assert := assert.New(t)
+	guild := &guild2.Guild{ID: "test-id"}
+	member := &member2.Member{ID: "test-member"}
+	spotInput := &spot.Spot{Name: "Prison -1", ID: 1}
+
+	today := time.Now()
+	existingStart := time.Date(today.Year(), today.Month(), today.Day(), 16, 0, 0, 0, time.UTC)
+	existingEnd := time.Date(today.Year(), today.Month(), today.Day(), 17, 0, 0, 0, time.UTC)
+	requestStart := existingEnd
+	requestEnd := time.Date(today.Year(), today.Month(), today.Day(), 18, 0, 0, 0, time.UTC)
+
+	spotRepo := mocks.NewMockSpotRepository(t)
+	spotRepo.On("SelectAllSpots", mocks.ContextMock).Return([]*spot.Spot{spotInput}, nil)
+
+	repo := mocks.NewMockReservationRepository(t)
+
+	existingRes := []*reservation.ReservationWithSpot{
+		{Reservation: reservation.Reservation{ID: 10, StartAt: existingStart, EndAt: existingEnd, SpotID: 1}, Spot: reservation.Spot{ID: 1, Name: "Prison -1"}},
+	}
+	repo.On("SelectUpcomingMemberReservationsWithSpots", mocks.ContextMock, guild, member).Return(existingRes, nil).Once()
+	repo.On("SelectOverlappingReservations", mocks.ContextMock, spotInput.Name, requestStart, requestEnd, guild.ID).Return([]*reservation.Reservation{}, nil).Once()
+	repo.On("CreateAndDeleteConflicting", mocks.ContextMock, member, guild, []*reservation.Reservation{}, int64(1), requestStart, requestEnd).Return([]*reservation.ClippedOrRemovedReservation{}, nil).Once()
+
+	updatedResList := []*reservation.ReservationWithSpot{
+		{Reservation: reservation.Reservation{ID: 10, StartAt: existingStart, EndAt: existingEnd, SpotID: 1}, Spot: reservation.Spot{ID: 1, Name: "Prison -1"}},
+		{Reservation: reservation.Reservation{ID: 11, StartAt: requestStart, EndAt: requestEnd, SpotID: 1}, Spot: reservation.Spot{ID: 1, Name: "Prison -1"}},
+	}
+	repo.On("SelectUpcomingMemberReservationsWithSpots", mocks.ContextMock, guild, member).Return(updatedResList, nil).Once()
+	repo.On("UpdateReservation", mocks.ContextMock, int64(10), existingStart, requestEnd).Return(nil).Once()
+	repo.On("DeletePresentMemberReservation", mocks.ContextMock, guild, member, int64(11)).Return(nil).Once()
+
+	adapter := NewAdapter(spotRepo, repo, mocks.NewMockCommunicationService(t))
+
+	_, err := adapter.Book(book.BookRequest{
+		Member:         member,
+		Guild:          guild,
+		Spot:           spotInput.Name,
+		StartAt:        requestStart,
+		EndAt:          requestEnd,
+		Overbook:       true,
+		HasPermissions: true,
+	})
+
+	assert.Nil(err)
+}

--- a/internal/core/booking/booking_test.go
+++ b/internal/core/booking/booking_test.go
@@ -528,7 +528,7 @@ func TestBook_PostMerge(t *testing.T) {
 	requestEnd := time.Date(today.Year(), today.Month(), today.Day(), 18, 0, 0, 0, time.UTC)
 
 	spotRepo := mocks.NewMockSpotRepository(t)
-	spotRepo.On("SelectAllSpots", mocks.ContextMock).Return([]*spot.Spot{spotInput}, nil)
+	spotRepo.On("SelectSpotByName", mocks.ContextMock, spotInput.Name).Return(spotInput, nil)
 
 	repo := mocks.NewMockReservationRepository(t)
 

--- a/internal/core/booking/merge.go
+++ b/internal/core/booking/merge.go
@@ -1,0 +1,85 @@
+package booking
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"spot-assistant/internal/core/dto/book"
+	"spot-assistant/internal/core/dto/reservation"
+)
+
+func (a *Adapter) mergeAdjacentReservations(ctx context.Context, request book.BookRequest) error {
+	upcoming, err := a.reservationRepo.SelectUpcomingMemberReservationsWithSpots(ctx, request.Guild, request.Member)
+	if err != nil {
+		return err
+	}
+
+	mergedStartAt, mergedEndAt, mergedIDs, _ := calculateBookingMerge(upcoming, request.Spot, request.StartAt, request.EndAt)
+
+	if len(mergedIDs) <= 1 {
+		return nil
+	}
+
+	if err := validateHuntLength(mergedEndAt.Sub(mergedStartAt)); err != nil {
+		return err
+	}
+
+	primaryID := mergedIDs[0]
+	err = a.reservationRepo.UpdateReservation(ctx, primaryID, mergedStartAt, mergedEndAt)
+	if err != nil {
+		return err
+	}
+
+	for _, idToDelete := range mergedIDs[1:] {
+		err = a.reservationRepo.DeletePresentMemberReservation(ctx, request.Guild, request.Member, idToDelete)
+		if err != nil {
+			fmt.Printf("failed to delete bridged reservation %d: %v\n", idToDelete, err)
+		}
+	}
+
+	return nil
+}
+
+func calculateBookingMerge(
+	reservations []*reservation.ReservationWithSpot,
+	spotName string,
+	startAt, endAt time.Time,
+) (
+	mergedStartAt, mergedEndAt time.Time,
+	mergedIDs []int64,
+	unaffectedReservations []*reservation.ReservationWithSpot,
+) {
+	mergedStartAt = startAt
+	mergedEndAt = endAt
+
+	for _, r := range reservations {
+		if r.Spot.Name != spotName {
+			unaffectedReservations = append(unaffectedReservations, r)
+			continue
+		}
+
+		gapAfter := mergedStartAt.Sub(r.EndAt)
+		gapBefore := r.StartAt.Sub(mergedEndAt)
+
+		if mergedStartAt.After(r.EndAt) && gapAfter > time.Minute {
+			unaffectedReservations = append(unaffectedReservations, r)
+			continue
+		}
+
+		if r.StartAt.After(mergedEndAt) && gapBefore > time.Minute {
+			unaffectedReservations = append(unaffectedReservations, r)
+			continue
+		}
+
+		mergedIDs = append(mergedIDs, r.Reservation.ID)
+		if r.StartAt.Before(mergedStartAt) {
+			mergedStartAt = r.StartAt
+		}
+		if r.EndAt.After(mergedEndAt) {
+			mergedEndAt = r.EndAt
+		}
+	}
+
+	return
+}

--- a/internal/core/booking/merge.go
+++ b/internal/core/booking/merge.go
@@ -33,8 +33,8 @@ func (m *MergeResult) ReservationsToDelete() []int64 {
 
 const adjacencyTolerance = time.Minute
 
-func (a *Adapter) mergeAdjacentReservations(request book.BookRequest) error {
-	upcoming, err := a.reservationRepo.SelectUpcomingMemberReservationsWithSpots(context.Background(), request.Guild, request.Member)
+func (a *Adapter) mergeAdjacentReservations(ctx context.Context, request book.BookRequest) error {
+	upcoming, err := a.reservationRepo.SelectUpcomingMemberReservationsWithSpots(ctx, request.Guild, request.Member)
 	if err != nil {
 		return fmt.Errorf("failed to fetch upcoming reservations: %w", err)
 	}
@@ -50,7 +50,7 @@ func (a *Adapter) mergeAdjacentReservations(request book.BookRequest) error {
 		return fmt.Errorf("merged reservation would exceed maximum length: %w", err)
 	}
 
-	return a.executeMerge(request, mergeResult)
+	return a.executeMerge(ctx, request, mergeResult)
 }
 
 func analyzeAdjacentReservations(
@@ -73,14 +73,14 @@ func analyzeAdjacentReservations(
 	return result
 }
 
-func (a *Adapter) executeMerge(request book.BookRequest, result *MergeResult) error {
+func (a *Adapter) executeMerge(ctx context.Context, request book.BookRequest, result *MergeResult) error {
 	primaryID := result.PrimaryReservationID()
 
-	if err := a.updateTimeOfMergedReservation(primaryID, result.MergedStartAt, result.MergedEndAt); err != nil {
+	if err := a.updateTimeOfMergedReservation(ctx, primaryID, result.MergedStartAt, result.MergedEndAt); err != nil {
 		return fmt.Errorf("failed to update primary reservation %d: %w", primaryID, err)
 	}
 
-	if err := a.deleteMergedReservations(request, result.ReservationsToDelete()); err != nil {
+	if err := a.deleteMergedReservations(ctx, request, result.ReservationsToDelete()); err != nil {
 		return fmt.Errorf("failed to delete merged reservations: %w", err)
 	}
 
@@ -131,13 +131,13 @@ func includeReservationInMerge(result *MergeResult, r *reservation.ReservationWi
 	}
 }
 
-func (a *Adapter) updateTimeOfMergedReservation(primaryID int64, startAt, endAt time.Time) error {
-	return a.reservationRepo.UpdateReservation(context.Background(), primaryID, startAt, endAt)
+func (a *Adapter) updateTimeOfMergedReservation(ctx context.Context, primaryID int64, startAt, endAt time.Time) error {
+	return a.reservationRepo.UpdateReservation(ctx, primaryID, startAt, endAt)
 }
 
-func (a *Adapter) deleteMergedReservations(request book.BookRequest, idsToDelete []int64) error {
+func (a *Adapter) deleteMergedReservations(ctx context.Context, request book.BookRequest, idsToDelete []int64) error {
 	for _, idToDelete := range idsToDelete {
-		if err := a.reservationRepo.DeletePresentMemberReservation(context.Background(), request.Guild, request.Member, idToDelete); err != nil {
+		if err := a.reservationRepo.DeletePresentMemberReservation(ctx, request.Guild, request.Member, idToDelete); err != nil {
 			return err
 		}
 	}

--- a/internal/core/booking/merge.go
+++ b/internal/core/booking/merge.go
@@ -5,81 +5,141 @@ import (
 	"fmt"
 	"time"
 
+	"spot-assistant/internal/common/collections"
 	"spot-assistant/internal/core/dto/book"
 	"spot-assistant/internal/core/dto/reservation"
 )
 
-func (a *Adapter) mergeAdjacentReservations(ctx context.Context, request book.BookRequest) error {
-	upcoming, err := a.reservationRepo.SelectUpcomingMemberReservationsWithSpots(ctx, request.Guild, request.Member)
+type MergeResult struct {
+	ShouldMerge          bool
+	MergedStartAt        time.Time
+	MergedEndAt          time.Time
+	MergedReservationIDs []int64
+}
+
+func (m *MergeResult) PrimaryReservationID() int64 {
+	if len(m.MergedReservationIDs) == 0 {
+		return 0
+	}
+	return m.MergedReservationIDs[0]
+}
+
+func (m *MergeResult) ReservationsToDelete() []int64 {
+	if len(m.MergedReservationIDs) <= 1 {
+		return nil
+	}
+	return m.MergedReservationIDs[1:]
+}
+
+const adjacencyTolerance = time.Minute
+
+func (a *Adapter) mergeAdjacentReservations(request book.BookRequest) error {
+	upcoming, err := a.reservationRepo.SelectUpcomingMemberReservationsWithSpots(context.Background(), request.Guild, request.Member)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to fetch upcoming reservations: %w", err)
 	}
 
-	mergedStartAt, mergedEndAt, mergedIDs, _ := calculateBookingMerge(upcoming, request.Spot, request.StartAt, request.EndAt)
+	matchingSpot := filterReservationsBySpot(upcoming, request.Spot)
+	mergeResult := analyzeAdjacentReservations(matchingSpot, request.StartAt, request.EndAt)
 
-	if len(mergedIDs) <= 1 {
+	if !mergeResult.ShouldMerge {
 		return nil
 	}
 
-	if err := validateHuntLength(mergedEndAt.Sub(mergedStartAt)); err != nil {
-		return err
+	if err := validateHuntLength(calculateMergedDuration(mergeResult)); err != nil {
+		return fmt.Errorf("merged reservation would exceed maximum length: %w", err)
 	}
 
-	primaryID := mergedIDs[0]
-	err = a.reservationRepo.UpdateReservation(ctx, primaryID, mergedStartAt, mergedEndAt)
-	if err != nil {
-		return err
+	return a.executeMerge(request, mergeResult)
+}
+
+func analyzeAdjacentReservations(
+	reservations []*reservation.ReservationWithSpot,
+	newReservationStart, newReservationEnd time.Time,
+) *MergeResult {
+	result := &MergeResult{
+		MergedStartAt:        newReservationStart,
+		MergedEndAt:          newReservationEnd,
+		MergedReservationIDs: make([]int64, 0),
 	}
 
-	for _, idToDelete := range mergedIDs[1:] {
-		err = a.reservationRepo.DeletePresentMemberReservation(ctx, request.Guild, request.Member, idToDelete)
-		if err != nil {
-			fmt.Printf("failed to delete bridged reservation %d: %v\n", idToDelete, err)
+	for _, r := range reservations {
+		if isReservationAdjacentToMergedRange(result.MergedStartAt, result.MergedEndAt, r) {
+			includeReservationInMerge(result, r)
 		}
 	}
+
+	result.ShouldMerge = len(result.MergedReservationIDs) > 1
+	return result
+}
+
+func (a *Adapter) executeMerge(request book.BookRequest, result *MergeResult) error {
+	primaryID := result.PrimaryReservationID()
+
+	if err := a.updateTimeOfMergedReservation(primaryID, result.MergedStartAt, result.MergedEndAt); err != nil {
+		return fmt.Errorf("failed to update primary reservation %d: %w", primaryID, err)
+	}
+
+	if err := a.deleteMergedReservations(request, result.ReservationsToDelete()); err != nil {
+		return fmt.Errorf("failed to delete merged reservations: %w", err)
+	}
+
+	a.log.With(
+		"primaryID", primaryID,
+		"deletedIDs", result.ReservationsToDelete(),
+		"mergedStart", result.MergedStartAt,
+		"mergedEnd", result.MergedEndAt,
+		"spot", request.Spot,
+	).Info("successfully merged adjacent reservations")
 
 	return nil
 }
 
-func calculateBookingMerge(
-	reservations []*reservation.ReservationWithSpot,
-	spotName string,
-	startAt, endAt time.Time,
-) (
-	mergedStartAt, mergedEndAt time.Time,
-	mergedIDs []int64,
-	unaffectedReservations []*reservation.ReservationWithSpot,
-) {
-	mergedStartAt = startAt
-	mergedEndAt = endAt
+func filterReservationsBySpot(reservations []*reservation.ReservationWithSpot, spotName string) []*reservation.ReservationWithSpot {
+	return collections.PoorMansFilter(reservations, func(r *reservation.ReservationWithSpot) bool {
+		return r.Spot.Name == spotName
+	})
+}
 
-	for _, r := range reservations {
-		if r.Spot.Name != spotName {
-			unaffectedReservations = append(unaffectedReservations, r)
-			continue
-		}
+func calculateMergedDuration(result *MergeResult) time.Duration {
+	return result.MergedEndAt.Sub(result.MergedStartAt)
+}
 
-		gapAfter := mergedStartAt.Sub(r.EndAt)
-		gapBefore := r.StartAt.Sub(mergedEndAt)
+func isReservationAdjacentToMergedRange(mergedStart, mergedEnd time.Time, r *reservation.ReservationWithSpot) bool {
+	gapAfter := mergedStart.Sub(r.EndAt)
+	gapBefore := r.StartAt.Sub(mergedEnd)
 
-		if mergedStartAt.After(r.EndAt) && gapAfter > time.Minute {
-			unaffectedReservations = append(unaffectedReservations, r)
-			continue
-		}
-
-		if r.StartAt.After(mergedEndAt) && gapBefore > time.Minute {
-			unaffectedReservations = append(unaffectedReservations, r)
-			continue
-		}
-
-		mergedIDs = append(mergedIDs, r.Reservation.ID)
-		if r.StartAt.Before(mergedStartAt) {
-			mergedStartAt = r.StartAt
-		}
-		if r.EndAt.After(mergedEndAt) {
-			mergedEndAt = r.EndAt
-		}
+	if mergedStart.After(r.EndAt) && gapAfter > adjacencyTolerance {
+		return false
 	}
 
-	return
+	if r.StartAt.After(mergedEnd) && gapBefore > adjacencyTolerance {
+		return false
+	}
+
+	return true
+}
+
+func includeReservationInMerge(result *MergeResult, r *reservation.ReservationWithSpot) {
+	result.MergedReservationIDs = append(result.MergedReservationIDs, r.Reservation.ID)
+
+	if r.StartAt.Before(result.MergedStartAt) {
+		result.MergedStartAt = r.StartAt
+	}
+	if r.EndAt.After(result.MergedEndAt) {
+		result.MergedEndAt = r.EndAt
+	}
+}
+
+func (a *Adapter) updateTimeOfMergedReservation(primaryID int64, startAt, endAt time.Time) error {
+	return a.reservationRepo.UpdateReservation(context.Background(), primaryID, startAt, endAt)
+}
+
+func (a *Adapter) deleteMergedReservations(request book.BookRequest, idsToDelete []int64) error {
+	for _, idToDelete := range idsToDelete {
+		if err := a.reservationRepo.DeletePresentMemberReservation(context.Background(), request.Guild, request.Member, idToDelete); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/core/booking/merge_test.go
+++ b/internal/core/booking/merge_test.go
@@ -1,0 +1,334 @@
+package booking
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"spot-assistant/internal/common/test/mocks"
+	"spot-assistant/internal/core/dto/book"
+	"spot-assistant/internal/core/dto/guild"
+	"spot-assistant/internal/core/dto/member"
+	"spot-assistant/internal/core/dto/reservation"
+)
+
+func TestCalculateBookingMerge(t *testing.T) {
+	today := time.Now()
+	mkTime := func(h, m int) time.Time {
+		return time.Date(today.Year(), today.Month(), today.Day(), h, m, 0, 0, time.UTC)
+	}
+
+	tests := []struct {
+		name           string
+		reservations   []*reservation.ReservationWithSpot
+		spotName       string
+		startAt        time.Time
+		endAt          time.Time
+		wantStart      time.Time
+		wantEnd        time.Time
+		wantMergedIDs  []int64
+		wantUnaffected int
+	}{
+		{
+			name:           "no existing reservations",
+			reservations:   []*reservation.ReservationWithSpot{},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(10, 0),
+			wantEnd:        mkTime(11, 0),
+			wantMergedIDs:  nil,
+			wantUnaffected: 0,
+		},
+		{
+			name: "no overlap - gap exceeds tolerance",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(8, 0), EndAt: mkTime(9, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 2),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(10, 2),
+			wantEnd:        mkTime(11, 0),
+			wantMergedIDs:  nil,
+			wantUnaffected: 1,
+		},
+		{
+			name: "exact adjacency - append",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(9, 0),
+			wantEnd:        mkTime(11, 0),
+			wantMergedIDs:  []int64{1},
+			wantUnaffected: 0,
+		},
+		{
+			name: "exact adjacency - prepend",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(10, 0),
+			wantEnd:        mkTime(12, 0),
+			wantMergedIDs:  []int64{1},
+			wantUnaffected: 0,
+		},
+		{
+			name: "1 minute gap - within tolerance",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 1),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(9, 0),
+			wantEnd:        mkTime(11, 0),
+			wantMergedIDs:  []int64{1},
+			wantUnaffected: 0,
+		},
+		{
+			name: "overlap",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 30)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(9, 0),
+			wantEnd:        mkTime(11, 0),
+			wantMergedIDs:  []int64{1},
+			wantUnaffected: 0,
+		},
+		{
+			name: "fully contained",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(9, 0),
+			wantEnd:        mkTime(12, 0),
+			wantMergedIDs:  []int64{1},
+			wantUnaffected: 0,
+		},
+		{
+			name: "different spot - no merge",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: "Spot-2"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(10, 0),
+			wantEnd:        mkTime(11, 0),
+			wantMergedIDs:  nil,
+			wantUnaffected: 1,
+		},
+		{
+			name: "bridge multiple reservations",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(9, 0),
+			wantEnd:        mkTime(12, 0),
+			wantMergedIDs:  []int64{1, 2},
+			wantUnaffected: 0,
+		},
+		{
+			name: "mixed spots - only merge matching",
+			reservations: []*reservation.ReservationWithSpot{
+				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: "Spot-2"}},
+				{Reservation: reservation.Reservation{ID: 3, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+			},
+			spotName:       "Spot-1",
+			startAt:        mkTime(10, 0),
+			endAt:          mkTime(11, 0),
+			wantStart:      mkTime(9, 0),
+			wantEnd:        mkTime(12, 0),
+			wantMergedIDs:  []int64{1, 3},
+			wantUnaffected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStart, gotEnd, gotIDs, gotUnaffected := calculateBookingMerge(
+				tt.reservations,
+				tt.spotName,
+				tt.startAt,
+				tt.endAt,
+			)
+
+			assert.Equal(t, tt.wantStart, gotStart)
+			assert.Equal(t, tt.wantEnd, gotEnd)
+			assert.ElementsMatch(t, tt.wantMergedIDs, gotIDs)
+			assert.Len(t, gotUnaffected, tt.wantUnaffected)
+		})
+	}
+}
+
+func TestMergeAdjacentReservations(t *testing.T) {
+	today := time.Now()
+	mkTime := func(h, m int) time.Time {
+		return time.Date(today.Year(), today.Month(), today.Day(), h, m, 0, 0, time.UTC)
+	}
+
+	guildID := &guild.Guild{ID: "g1"}
+	memberID := &member.Member{ID: "m1"}
+	spotName := "Spot-1"
+
+	t.Run("no merge needed", func(t *testing.T) {
+		repo := mocks.NewMockReservationRepository(t)
+		adapter := NewAdapter(nil, repo, nil)
+
+		existing := []*reservation.ReservationWithSpot{
+			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(8, 0), EndAt: mkTime(9, 0)}, Spot: reservation.Spot{Name: spotName}},
+		}
+		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
+
+		req := book.BookRequest{
+			Guild:   guildID,
+			Member:  memberID,
+			Spot:    spotName,
+			StartAt: mkTime(10, 0),
+			EndAt:   mkTime(11, 0),
+		}
+
+		err := adapter.mergeAdjacentReservations(context.Background(), req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("simple merge - two adjacent reservations", func(t *testing.T) {
+		repo := mocks.NewMockReservationRepository(t)
+		adapter := NewAdapter(nil, repo, nil)
+
+		existing := []*reservation.ReservationWithSpot{
+			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: spotName}},
+			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
+		}
+		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
+		repo.On("UpdateReservation", mock.Anything, int64(1), mkTime(9, 0), mkTime(11, 0)).Return(nil)
+		repo.On("DeletePresentMemberReservation", mock.Anything, guildID, memberID, int64(2)).Return(nil)
+
+		req := book.BookRequest{
+			Guild:   guildID,
+			Member:  memberID,
+			Spot:    spotName,
+			StartAt: mkTime(10, 0),
+			EndAt:   mkTime(11, 0),
+		}
+
+		err := adapter.mergeAdjacentReservations(context.Background(), req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("bridge three reservations", func(t *testing.T) {
+		repo := mocks.NewMockReservationRepository(t)
+		adapter := NewAdapter(nil, repo, nil)
+
+		existing := []*reservation.ReservationWithSpot{
+			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: spotName}},
+			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
+			{Reservation: reservation.Reservation{ID: 3, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: spotName}},
+		}
+		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
+		repo.On("UpdateReservation", mock.Anything, int64(1), mkTime(9, 0), mkTime(12, 0)).Return(nil)
+		repo.On("DeletePresentMemberReservation", mock.Anything, guildID, memberID, int64(2)).Return(nil)
+		repo.On("DeletePresentMemberReservation", mock.Anything, guildID, memberID, int64(3)).Return(nil)
+
+		req := book.BookRequest{
+			Guild:   guildID,
+			Member:  memberID,
+			Spot:    spotName,
+			StartAt: mkTime(10, 0),
+			EndAt:   mkTime(11, 0),
+		}
+
+		err := adapter.mergeAdjacentReservations(context.Background(), req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("validation error - merged duration exceeds limit", func(t *testing.T) {
+		repo := mocks.NewMockReservationRepository(t)
+		adapter := NewAdapter(nil, repo, nil)
+
+		existing := []*reservation.ReservationWithSpot{
+			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
+			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(11, 0), EndAt: mkTime(13, 0)}, Spot: reservation.Spot{Name: spotName}},
+		}
+		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
+
+		req := book.BookRequest{
+			Guild:   guildID,
+			Member:  memberID,
+			Spot:    spotName,
+			StartAt: mkTime(11, 0),
+			EndAt:   mkTime(13, 0),
+		}
+
+		err := adapter.mergeAdjacentReservations(context.Background(), req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "reservation cannot take more than 3 hours")
+	})
+
+	t.Run("repository error - select fails", func(t *testing.T) {
+		repo := mocks.NewMockReservationRepository(t)
+		adapter := NewAdapter(nil, repo, nil)
+
+		repoErr := fmt.Errorf("database connection failed")
+		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(nil, repoErr)
+
+		req := book.BookRequest{
+			Guild:   guildID,
+			Member:  memberID,
+			Spot:    spotName,
+			StartAt: mkTime(10, 0),
+			EndAt:   mkTime(11, 0),
+		}
+
+		err := adapter.mergeAdjacentReservations(context.Background(), req)
+		assert.Error(t, err)
+		assert.Equal(t, repoErr, err)
+	})
+
+	t.Run("repository error - update fails", func(t *testing.T) {
+		repo := mocks.NewMockReservationRepository(t)
+		adapter := NewAdapter(nil, repo, nil)
+
+		existing := []*reservation.ReservationWithSpot{
+			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: spotName}},
+			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
+		}
+		updateErr := fmt.Errorf("update failed")
+		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
+		repo.On("UpdateReservation", mock.Anything, int64(1), mkTime(9, 0), mkTime(11, 0)).Return(updateErr)
+
+		req := book.BookRequest{
+			Guild:   guildID,
+			Member:  memberID,
+			Spot:    spotName,
+			StartAt: mkTime(10, 0),
+			EndAt:   mkTime(11, 0),
+		}
+
+		err := adapter.mergeAdjacentReservations(context.Background(), req)
+		assert.Error(t, err)
+		assert.Equal(t, updateErr, err)
+	})
+}

--- a/internal/core/booking/merge_test.go
+++ b/internal/core/booking/merge_test.go
@@ -1,8 +1,6 @@
 package booking
 
 import (
-	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -16,319 +14,192 @@ import (
 	"spot-assistant/internal/core/dto/reservation"
 )
 
-func TestCalculateBookingMerge(t *testing.T) {
-	today := time.Now()
-	mkTime := func(h, m int) time.Time {
-		return time.Date(today.Year(), today.Month(), today.Day(), h, m, 0, 0, time.UTC)
+func TestAnalyzeAdjacentReservations(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	createRes := func(id int64, start, end time.Time) *reservation.ReservationWithSpot {
+		return &reservation.ReservationWithSpot{
+			Reservation: reservation.Reservation{ID: id, StartAt: start, EndAt: end},
+			Spot:        reservation.Spot{ID: 1, Name: "test-spot"},
+		}
 	}
 
 	tests := []struct {
-		name           string
-		reservations   []*reservation.ReservationWithSpot
-		spotName       string
-		startAt        time.Time
-		endAt          time.Time
-		wantStart      time.Time
-		wantEnd        time.Time
-		wantMergedIDs  []int64
-		wantUnaffected int
+		name               string
+		reservations       []*reservation.ReservationWithSpot
+		inputStart         time.Time
+		inputEnd           time.Time
+		wantShouldMerge    bool
+		wantStart          time.Time
+		wantEnd            time.Time
+		wantReservationIDs []int64
 	}{
 		{
-			name:           "no existing reservations",
-			reservations:   []*reservation.ReservationWithSpot{},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(10, 0),
-			wantEnd:        mkTime(11, 0),
-			wantMergedIDs:  nil,
-			wantUnaffected: 0,
+			name:               "Single reservation returns false",
+			reservations:       []*reservation.ReservationWithSpot{createRes(1, now, now.Add(time.Hour))},
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    false,
+			wantStart:          now,
+			wantEnd:            now.Add(time.Hour),
+			wantReservationIDs: []int64{1},
 		},
 		{
-			name: "no overlap - gap exceeds tolerance",
+			name: "Two unrelated reservations returns false",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(8, 0), EndAt: mkTime(9, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(3*time.Hour), now.Add(4*time.Hour)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 2),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(10, 2),
-			wantEnd:        mkTime(11, 0),
-			wantMergedIDs:  nil,
-			wantUnaffected: 1,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    false,
+			wantStart:          now,
+			wantEnd:            now.Add(time.Hour),
+			wantReservationIDs: []int64{1},
 		},
 		{
-			name: "exact adjacency - append",
+			name: "Exact adjacency after returns true",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(time.Hour), now.Add(2*time.Hour)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(9, 0),
-			wantEnd:        mkTime(11, 0),
-			wantMergedIDs:  []int64{1},
-			wantUnaffected: 0,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    true,
+			wantStart:          now,
+			wantEnd:            now.Add(2 * time.Hour),
+			wantReservationIDs: []int64{1, 2},
 		},
 		{
-			name: "exact adjacency - prepend",
+			name: "Exact adjacency before returns true",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(-1*time.Hour), now),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(10, 0),
-			wantEnd:        mkTime(12, 0),
-			wantMergedIDs:  []int64{1},
-			wantUnaffected: 0,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    true,
+			wantStart:          now.Add(-1 * time.Hour),
+			wantEnd:            now.Add(time.Hour),
+			wantReservationIDs: []int64{1, 2},
 		},
 		{
-			name: "1 minute gap - within tolerance",
+			name: "Gap within tolerance returns true",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(time.Hour).Add(30*time.Second), now.Add(2*time.Hour)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 1),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(9, 0),
-			wantEnd:        mkTime(11, 0),
-			wantMergedIDs:  []int64{1},
-			wantUnaffected: 0,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    true,
+			wantStart:          now,
+			wantEnd:            now.Add(2 * time.Hour),
+			wantReservationIDs: []int64{1, 2},
 		},
 		{
-			name: "overlap",
+			name: "Gap exactly at tolerance returns true",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 30)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(time.Hour).Add(time.Minute), now.Add(2*time.Hour)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(9, 0),
-			wantEnd:        mkTime(11, 0),
-			wantMergedIDs:  []int64{1},
-			wantUnaffected: 0,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    true,
+			wantStart:          now,
+			wantEnd:            now.Add(2 * time.Hour),
+			wantReservationIDs: []int64{1, 2},
 		},
 		{
-			name: "fully contained",
+			name: "Gap exceeding tolerance returns false",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(time.Hour).Add(time.Minute).Add(time.Nanosecond), now.Add(2*time.Hour)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(9, 0),
-			wantEnd:        mkTime(12, 0),
-			wantMergedIDs:  []int64{1},
-			wantUnaffected: 0,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    false,
+			wantStart:          now,
+			wantEnd:            now.Add(time.Hour),
+			wantReservationIDs: []int64{1},
 		},
 		{
-			name: "different spot - no merge",
+			name: "Bridging two reservations returns true",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: "Spot-2"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(-1*time.Hour), now),
+				createRes(3, now.Add(time.Hour), now.Add(2*time.Hour)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(10, 0),
-			wantEnd:        mkTime(11, 0),
-			wantMergedIDs:  nil,
-			wantUnaffected: 1,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    true,
+			wantStart:          now.Add(-1 * time.Hour),
+			wantEnd:            now.Add(2 * time.Hour),
+			wantReservationIDs: []int64{1, 2, 3},
 		},
 		{
-			name: "bridge multiple reservations",
+			name: "Subset violation returns true",
 			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
-				{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
+				createRes(1, now, now.Add(time.Hour)),
+				createRes(2, now.Add(-30*time.Minute), now.Add(30*time.Minute)),
 			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(9, 0),
-			wantEnd:        mkTime(12, 0),
-			wantMergedIDs:  []int64{1, 2},
-			wantUnaffected: 0,
-		},
-		{
-			name: "mixed spots - only merge matching",
-			reservations: []*reservation.ReservationWithSpot{
-				{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
-				{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: "Spot-2"}},
-				{Reservation: reservation.Reservation{ID: 3, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: "Spot-1"}},
-			},
-			spotName:       "Spot-1",
-			startAt:        mkTime(10, 0),
-			endAt:          mkTime(11, 0),
-			wantStart:      mkTime(9, 0),
-			wantEnd:        mkTime(12, 0),
-			wantMergedIDs:  []int64{1, 3},
-			wantUnaffected: 1,
+			inputStart:         now,
+			inputEnd:           now.Add(time.Hour),
+			wantShouldMerge:    true,
+			wantStart:          now.Add(-30 * time.Minute),
+			wantEnd:            now.Add(time.Hour),
+			wantReservationIDs: []int64{1, 2},
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			gotStart, gotEnd, gotIDs, gotUnaffected := calculateBookingMerge(
-				tt.reservations,
-				tt.spotName,
-				tt.startAt,
-				tt.endAt,
-			)
+			t.Parallel()
+			got := analyzeAdjacentReservations(tt.reservations, tt.inputStart, tt.inputEnd)
 
-			assert.Equal(t, tt.wantStart, gotStart)
-			assert.Equal(t, tt.wantEnd, gotEnd)
-			assert.ElementsMatch(t, tt.wantMergedIDs, gotIDs)
-			assert.Len(t, gotUnaffected, tt.wantUnaffected)
+			assert.Equal(t, tt.wantShouldMerge, got.ShouldMerge)
+			assert.WithinDuration(t, tt.wantStart, got.MergedStartAt, time.Second)
+			assert.WithinDuration(t, tt.wantEnd, got.MergedEndAt, time.Second)
+			assert.ElementsMatch(t, tt.wantReservationIDs, got.MergedReservationIDs)
 		})
 	}
 }
 
 func TestMergeAdjacentReservations(t *testing.T) {
-	today := time.Now()
-	mkTime := func(h, m int) time.Time {
-		return time.Date(today.Year(), today.Month(), today.Day(), h, m, 0, 0, time.UTC)
+	assert := assert.New(t)
+	mockRepo := mocks.NewMockReservationRepository(t)
+	mockSpotRepo := mocks.NewMockSpotRepository(t)
+	mockComm := mocks.NewMockCommunicationService(t)
+	adapter := NewAdapter(mockSpotRepo, mockRepo, mockComm)
+	now := time.Now()
+
+	createRes := func(id int64, start, end time.Time) *reservation.ReservationWithSpot {
+		return &reservation.ReservationWithSpot{
+			Reservation: reservation.Reservation{ID: id, StartAt: start, EndAt: end},
+			Spot:        reservation.Spot{ID: 1, Name: "test-spot"},
+		}
 	}
 
-	guildID := &guild.Guild{ID: "g1"}
-	memberID := &member.Member{ID: "m1"}
-	spotName := "Spot-1"
+	req := book.BookRequest{
+		Guild:   &guild.Guild{ID: "g1"},
+		Member:  &member.Member{ID: "m1"},
+		Spot:    "test-spot",
+		StartAt: now,
+		EndAt:   now.Add(time.Hour),
+	}
 
-	t.Run("no merge needed", func(t *testing.T) {
-		repo := mocks.NewMockReservationRepository(t)
-		adapter := NewAdapter(nil, repo, nil)
+	reservations := []*reservation.ReservationWithSpot{
+		createRes(10, now, now.Add(time.Hour)),
+		createRes(11, now.Add(time.Hour), now.Add(2*time.Hour)),
+	}
 
-		existing := []*reservation.ReservationWithSpot{
-			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(8, 0), EndAt: mkTime(9, 0)}, Spot: reservation.Spot{Name: spotName}},
-		}
-		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
+	mockRepo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, req.Guild, req.Member).Return(reservations, nil)
+	mockRepo.On("UpdateReservation", mock.Anything, int64(10), now, now.Add(2*time.Hour)).Return(nil)
+	mockRepo.On("DeletePresentMemberReservation", mock.Anything, req.Guild, req.Member, int64(11)).Return(nil)
 
-		req := book.BookRequest{
-			Guild:   guildID,
-			Member:  memberID,
-			Spot:    spotName,
-			StartAt: mkTime(10, 0),
-			EndAt:   mkTime(11, 0),
-		}
+	err := adapter.mergeAdjacentReservations(req)
 
-		err := adapter.mergeAdjacentReservations(context.Background(), req)
-		assert.NoError(t, err)
-	})
-
-	t.Run("simple merge - two adjacent reservations", func(t *testing.T) {
-		repo := mocks.NewMockReservationRepository(t)
-		adapter := NewAdapter(nil, repo, nil)
-
-		existing := []*reservation.ReservationWithSpot{
-			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: spotName}},
-			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
-		}
-		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
-		repo.On("UpdateReservation", mock.Anything, int64(1), mkTime(9, 0), mkTime(11, 0)).Return(nil)
-		repo.On("DeletePresentMemberReservation", mock.Anything, guildID, memberID, int64(2)).Return(nil)
-
-		req := book.BookRequest{
-			Guild:   guildID,
-			Member:  memberID,
-			Spot:    spotName,
-			StartAt: mkTime(10, 0),
-			EndAt:   mkTime(11, 0),
-		}
-
-		err := adapter.mergeAdjacentReservations(context.Background(), req)
-		assert.NoError(t, err)
-	})
-
-	t.Run("bridge three reservations", func(t *testing.T) {
-		repo := mocks.NewMockReservationRepository(t)
-		adapter := NewAdapter(nil, repo, nil)
-
-		existing := []*reservation.ReservationWithSpot{
-			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: spotName}},
-			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
-			{Reservation: reservation.Reservation{ID: 3, StartAt: mkTime(11, 0), EndAt: mkTime(12, 0)}, Spot: reservation.Spot{Name: spotName}},
-		}
-		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
-		repo.On("UpdateReservation", mock.Anything, int64(1), mkTime(9, 0), mkTime(12, 0)).Return(nil)
-		repo.On("DeletePresentMemberReservation", mock.Anything, guildID, memberID, int64(2)).Return(nil)
-		repo.On("DeletePresentMemberReservation", mock.Anything, guildID, memberID, int64(3)).Return(nil)
-
-		req := book.BookRequest{
-			Guild:   guildID,
-			Member:  memberID,
-			Spot:    spotName,
-			StartAt: mkTime(10, 0),
-			EndAt:   mkTime(11, 0),
-		}
-
-		err := adapter.mergeAdjacentReservations(context.Background(), req)
-		assert.NoError(t, err)
-	})
-
-	t.Run("validation error - merged duration exceeds limit", func(t *testing.T) {
-		repo := mocks.NewMockReservationRepository(t)
-		adapter := NewAdapter(nil, repo, nil)
-
-		existing := []*reservation.ReservationWithSpot{
-			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
-			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(11, 0), EndAt: mkTime(13, 0)}, Spot: reservation.Spot{Name: spotName}},
-		}
-		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
-
-		req := book.BookRequest{
-			Guild:   guildID,
-			Member:  memberID,
-			Spot:    spotName,
-			StartAt: mkTime(11, 0),
-			EndAt:   mkTime(13, 0),
-		}
-
-		err := adapter.mergeAdjacentReservations(context.Background(), req)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "reservation cannot take more than 3 hours")
-	})
-
-	t.Run("repository error - select fails", func(t *testing.T) {
-		repo := mocks.NewMockReservationRepository(t)
-		adapter := NewAdapter(nil, repo, nil)
-
-		repoErr := fmt.Errorf("database connection failed")
-		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(nil, repoErr)
-
-		req := book.BookRequest{
-			Guild:   guildID,
-			Member:  memberID,
-			Spot:    spotName,
-			StartAt: mkTime(10, 0),
-			EndAt:   mkTime(11, 0),
-		}
-
-		err := adapter.mergeAdjacentReservations(context.Background(), req)
-		assert.Error(t, err)
-		assert.Equal(t, repoErr, err)
-	})
-
-	t.Run("repository error - update fails", func(t *testing.T) {
-		repo := mocks.NewMockReservationRepository(t)
-		adapter := NewAdapter(nil, repo, nil)
-
-		existing := []*reservation.ReservationWithSpot{
-			{Reservation: reservation.Reservation{ID: 1, StartAt: mkTime(9, 0), EndAt: mkTime(10, 0)}, Spot: reservation.Spot{Name: spotName}},
-			{Reservation: reservation.Reservation{ID: 2, StartAt: mkTime(10, 0), EndAt: mkTime(11, 0)}, Spot: reservation.Spot{Name: spotName}},
-		}
-		updateErr := fmt.Errorf("update failed")
-		repo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, guildID, memberID).Return(existing, nil)
-		repo.On("UpdateReservation", mock.Anything, int64(1), mkTime(9, 0), mkTime(11, 0)).Return(updateErr)
-
-		req := book.BookRequest{
-			Guild:   guildID,
-			Member:  memberID,
-			Spot:    spotName,
-			StartAt: mkTime(10, 0),
-			EndAt:   mkTime(11, 0),
-		}
-
-		err := adapter.mergeAdjacentReservations(context.Background(), req)
-		assert.Error(t, err)
-		assert.Equal(t, updateErr, err)
-	})
+	assert.NoError(err)
+	mockRepo.AssertExpectations(t)
 }

--- a/internal/core/booking/merge_test.go
+++ b/internal/core/booking/merge_test.go
@@ -1,11 +1,11 @@
 package booking
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
 	"spot-assistant/internal/common/test/mocks"
 	"spot-assistant/internal/core/dto/book"
@@ -194,11 +194,11 @@ func TestMergeAdjacentReservations(t *testing.T) {
 		createRes(11, now.Add(time.Hour), now.Add(2*time.Hour)),
 	}
 
-	mockRepo.On("SelectUpcomingMemberReservationsWithSpots", mock.Anything, req.Guild, req.Member).Return(reservations, nil)
-	mockRepo.On("UpdateReservation", mock.Anything, int64(10), now, now.Add(2*time.Hour)).Return(nil)
-	mockRepo.On("DeletePresentMemberReservation", mock.Anything, req.Guild, req.Member, int64(11)).Return(nil)
+	mockRepo.On("SelectUpcomingMemberReservationsWithSpots", mocks.ContextMock, req.Guild, req.Member).Return(reservations, nil)
+	mockRepo.On("UpdateReservation", mocks.ContextMock, int64(10), now, now.Add(2*time.Hour)).Return(nil)
+	mockRepo.On("DeletePresentMemberReservation", mocks.ContextMock, req.Guild, req.Member, int64(11)).Return(nil)
 
-	err := adapter.mergeAdjacentReservations(req)
+	err := adapter.mergeAdjacentReservations(context.Background(), req)
 
 	assert.NoError(err)
 	mockRepo.AssertExpectations(t)

--- a/internal/infrastructure/reservation/postgresql/query/reservations.sql
+++ b/internal/infrastructure/reservation/postgresql/query/reservations.sql
@@ -73,4 +73,9 @@ where end_at >= now()
   AND lower(web_spot.name) = lower($2);
 -- name: DeleteReservation :exec
 DELETE FROM web_reservation
-WHERE web_reservation.id = $1;
+WHERE id = $1;
+-- name: UpdateReservation :exec
+UPDATE web_reservation
+SET start_at = @start_at,
+  end_at = @end_at
+WHERE id = @id;

--- a/internal/infrastructure/reservation/postgresql/sqlc/reservations.go
+++ b/internal/infrastructure/reservation/postgresql/sqlc/reservations.go
@@ -226,6 +226,26 @@ func (t *ReservationRepository) DeletePresentMemberReservation(ctx context.Conte
 	return nil
 }
 
+func (t *ReservationRepository) UpdateReservation(ctx context.Context, id int64, startAt time.Time, endAt time.Time) error {
+	startAtInput := pgtype.Timestamptz{}
+	err := startAtInput.Scan(startAt)
+	if err != nil {
+		return err
+	}
+
+	endAtInput := pgtype.Timestamptz{}
+	err = endAtInput.Scan(endAt)
+	if err != nil {
+		return err
+	}
+
+	return t.q.UpdateReservation(ctx, UpdateReservationParams{
+		StartAt: startAtInput,
+		EndAt:   endAtInput,
+		ID:      id,
+	})
+}
+
 // createOverbookedLeftovers creates up to two reservations from overbooked reservation leftovers.
 // If overbooked reservation starts before new reservation, a reservation is created from overbooked reservation start time till new reservation start time.
 // If overbooked reservation ends after new reservation, a reservation is created from new reservation end time till overbooked reservation end time.

--- a/internal/infrastructure/reservation/postgresql/sqlc/reservations.sql.go
+++ b/internal/infrastructure/reservation/postgresql/sqlc/reservations.sql.go
@@ -78,7 +78,7 @@ func (q *Queries) DeletePresentMemberReservation(ctx context.Context, arg Delete
 
 const deleteReservation = `-- name: DeleteReservation :exec
 DELETE FROM web_reservation
-WHERE web_reservation.id = $1
+WHERE id = $1
 `
 
 func (q *Queries) DeleteReservation(ctx context.Context, id int64) error {
@@ -366,4 +366,22 @@ func (q *Queries) SelectUpcomingMemberReservationsWithSpots(ctx context.Context,
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateReservation = `-- name: UpdateReservation :exec
+UPDATE web_reservation
+SET start_at = $1,
+  end_at = $2
+WHERE id = $3
+`
+
+type UpdateReservationParams struct {
+	StartAt pgtype.Timestamptz
+	EndAt   pgtype.Timestamptz
+	ID      int64
+}
+
+func (q *Queries) UpdateReservation(ctx context.Context, arg UpdateReservationParams) error {
+	_, err := q.db.Exec(ctx, updateReservation, arg.StartAt, arg.EndAt, arg.ID)
+	return err
 }

--- a/internal/ports/framework_right.go
+++ b/internal/ports/framework_right.go
@@ -30,6 +30,9 @@ type ReservationRepository interface {
 	// Deletes one of the upcoming member reservations in a given guild. Returns error if operation
 	// did not succeed.
 	DeletePresentMemberReservation(ctx context.Context, g *guild.Guild, m *member.Member, reservationId int64) error
+
+	// UpdateReservation updates the start and end time of a reservation.
+	UpdateReservation(ctx context.Context, id int64, startAt time.Time, endAt time.Time) error
 }
 
 type SpotRepository interface {


### PR DESCRIPTION
Implement automatic merging of adjacent reservations for the same user and spot to simplify booking management and improve UX.

Changes:
- Add mergeAdjacentReservations() post-processing step in Book() method
- Implement calculateBookingMerge() helper to detect mergeable reservations
- Add UpdateReservation method to ReservationRepository interface
- Upgrade dependencies: sqlc v1.26.0 → v1.29.0, pgx v5.5.5 → v5.7.4

The merge logic:
- Detects reservations within 1 minute of each other for same spot/user
- Extends the earliest reservation's time range
- Deletes redundant/bridged reservations
- Validates merged time doesn't exceed maximum hunt duration

This removes the need for users to manually manage multiple bookings and prevents fragmentation of reservation time slots.